### PR TITLE
Don't acquire lock for draft PRs

### DIFF
--- a/.github/workflows/terraform_lock.yml
+++ b/.github/workflows/terraform_lock.yml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+    if: ${{ github.event.pull_request.draft == false}}
     steps:
       - name: show event
         run: |


### PR DESCRIPTION
We shouldn't be trying to acquire locks for draft PRs, this prevents the workflow from running in that case.