### PR TITLE
a simpler required check

### DIFF
--- a/.github/workflows/required_check.yml
+++ b/.github/workflows/required_check.yml
@@ -1,10 +1,17 @@
 name: Required check
 
 on:
-  pull_request:
+  pull_request: null
 
 jobs:
-  tacos-gha:
-    uses: getsentry/tacos-gha/.github/workflows/required_check.yml@add-required-check-workflow
-    with:
-      tacos_gha_ref: refs/heads/add-required-check-workflow
+  required_check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Perform check
+        run: |
+          if [ -e required_check.fail ]; then exit 1; fi


### PR DESCRIPTION
Currently tests are failing because this shared workflow doesn't exist -- and there's no reason for it to be shared either. This is considerably simpler.